### PR TITLE
Add feature: Dynamic variables

### DIFF
--- a/handlers/dynamic_parameters.go
+++ b/handlers/dynamic_parameters.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/djatwood/formailer"
+)
+
+/*
+ReplaceDynamic replaces a dynamic value with submission data
+
+This is a {{dynamic}} value => This is a replaced value
+*/
+func ReplaceDynamic(str string, submission *formailer.Submission) string {
+	openIndex := -1
+	for i := range str[1:] {
+		switch str[i : i+2] {
+		case "{{":
+			openIndex = i
+		case "}}":
+			if openIndex < 0 {
+				continue
+			}
+
+			if v, ok := submission.Values[str[openIndex+2:i]]; ok {
+				str = str[:openIndex] + fmt.Sprint(v) + str[i+2:]
+			}
+		}
+	}
+
+	return str
+}

--- a/handlers/dynamic_parameters_test.go
+++ b/handlers/dynamic_parameters_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/djatwood/formailer"
+)
+
+func TestReplace(t *testing.T) {
+	submission := formailer.Submission{
+		Values: map[string]interface{}{
+			"name": "First Last",
+			"map": map[string]interface{}{
+				"kind": "map",
+			},
+		},
+	}
+
+	tests := map[string]interface{}{
+		"Prefix {{name}} Suffix": "Prefix First Last Suffix",
+		"{{map}}":                submission.Values["map"],
+		"name}}":                 nil,
+		"{{name":                 nil,
+		"{{notexist}}":           nil,
+	}
+
+	for test, expected := range tests {
+		if expected == nil {
+			expected = test
+		}
+		result := ReplaceDynamic(test, &submission)
+		if result != fmt.Sprint(expected) {
+			t.Errorf("unexpected result from replace\nExpected: %s\nGot: %s", expected, result)
+		}
+	}
+}

--- a/handlers/netlify.go
+++ b/handlers/netlify.go
@@ -53,6 +53,11 @@ func Netlify(c formailer.Forms) func(events.APIGatewayProxyRequest) (*events.API
 			delete(submission.Values, "g-recaptcha-response")
 		}
 
+		for _, email := range submission.Emails {
+			email.To = ReplaceDynamic(email.To, submission)
+			email.Subject = ReplaceDynamic(email.Subject, submission)
+		}
+
 		err = submission.Send()
 		if err != nil {
 			return netlifyResponse(http.StatusInternalServerError, err), nil

--- a/handlers/vercel.go
+++ b/handlers/vercel.go
@@ -53,6 +53,11 @@ func Vercel(c formailer.Forms, w http.ResponseWriter, r *http.Request) {
 		delete(submission.Values, "g-recaptcha-response")
 	}
 
+	for _, email := range submission.Emails {
+		email.To = ReplaceDynamic(email.To, submission)
+		email.Subject = ReplaceDynamic(email.Subject, submission)
+	}
+
 	err = submission.Send()
 	if err != nil {
 		vercelResponse(w, http.StatusInternalServerError, err)


### PR DESCRIPTION
Allowing dynamic variables is a very powerful feature. It can be used to customize the subject field or the recipient of the email. I'm still not happy with the current implementation because URLEncoded submissions use arrays instead of strings. Resulting in the following: `Custom subject about [issues]` instead of `Custom subject about issues`.
