### PR TITLE
Use supplied config in handlers

### DIFF
--- a/handlers/netlify.go
+++ b/handlers/netlify.go
@@ -46,7 +46,7 @@ func Netlify(c formailer.Config) func(events.APIGatewayProxyRequest) (*events.AP
 			return netlifyResponse(http.StatusMethodNotAllowed, nil), nil
 		}
 
-		submission, err := formailer.Parse(request.Headers["content-type"], request.Body)
+		submission, err := c.Parse(request.Headers["content-type"], request.Body)
 		if err != nil {
 			return netlifyResponse(http.StatusBadRequest, err), nil
 		}

--- a/handlers/vercel.go
+++ b/handlers/vercel.go
@@ -44,7 +44,7 @@ func Vercel(c formailer.Config, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	submission, err := formailer.Parse(r.Header.Get("Content-Type"), body.String())
+	submission, err := c.Parse(r.Header.Get("Content-Type"), body.String())
 	if err != nil {
 		vercelResponse(w, http.StatusBadRequest, err)
 		return


### PR DESCRIPTION
It seems there's a bug in the Netlify and Vercel handlers.

Even though a Config is being passed on to them, the DefaultConfig is still being forced.